### PR TITLE
feat: support ".finally()"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-draft/deferred-promise",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "deferred-promise",
-      "version": "0.0.0",
+      "name": "@open-draft/deferred-promise",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@ossjs/release": "^0.3.2",

--- a/test/DeferredPromise.test.ts
+++ b/test/DeferredPromise.test.ts
@@ -1,103 +1,136 @@
-import { DeferredPromise } from '../src'
+import { DeferredPromise } from "../src";
 
 it('can be listened to with ".then()"', (done) => {
-  expect.assertions(1)
+  expect.assertions(1);
 
-  const promise = new DeferredPromise<number>()
+  const promise = new DeferredPromise<number>();
 
   promise.then((data) => {
-    expect(data).toBe(123)
-    done()
-  })
+    expect(data).toBe(123);
+    done();
+  });
 
-  promise.resolve(123)
-})
+  promise.resolve(123);
+});
 
 it('can be listened to with ".catch()"', (done) => {
-  expect.assertions(1)
+  expect.assertions(1);
 
-  const promise = new DeferredPromise<number>()
+  const promise = new DeferredPromise<number>();
   promise.catch((reason) => {
-    expect(reason).toBe('error')
-    done()
-  })
+    expect(reason).toBe("error");
+    done();
+  });
 
-  promise.reject('error')
-})
+  promise.reject("error");
+});
 
-it('can be awaited', async () => {
-  const promise = new DeferredPromise<number>()
-  promise.resolve(123)
+it("can be awaited", async () => {
+  const promise = new DeferredPromise<number>();
+  promise.resolve(123);
 
-  const data = await promise
-  expect(data).toBe(123)
-})
+  const data = await promise;
+  expect(data).toBe(123);
+});
 
-describe('resolve()', () => {
-  it('can be resolved without data', () => {
-    const promise = new DeferredPromise<void>()
-    expect(promise.state).toBe('pending')
-    promise.resolve()
+describe("resolve()", () => {
+  it("can be resolved without data", () => {
+    const promise = new DeferredPromise<void>();
+    expect(promise.state).toBe("pending");
+    promise.resolve();
 
-    expect(promise.state).toBe('resolved')
-    expect(promise.result).toBeUndefined()
-  })
+    expect(promise.state).toBe("resolved");
+    expect(promise.result).toBeUndefined();
+  });
 
-  it('can be resolved with data', () => {
-    const promise = new DeferredPromise<number>()
-    expect(promise.state).toBe('pending')
+  it("can be resolved with data", () => {
+    const promise = new DeferredPromise<number>();
+    expect(promise.state).toBe("pending");
 
-    promise.resolve(123)
+    promise.resolve(123);
 
-    expect(promise.state).toBe('resolved')
-    expect(promise.result).toBe(123)
-  })
+    expect(promise.state).toBe("resolved");
+    expect(promise.result).toBe(123);
+  });
 
-  it('throws when resolving an already resolved promise', () => {
-    const promise = new DeferredPromise<number>()
-    expect(promise.state).toBe('pending')
-    promise.resolve(123)
+  it("throws when resolving an already resolved promise", () => {
+    const promise = new DeferredPromise<number>();
+    expect(promise.state).toBe("pending");
+    promise.resolve(123);
 
     expect(() => promise.resolve(456)).toThrow(
       new TypeError(
         'Cannot resolve a DeferredPromise: illegal state ("resolved")'
       )
-    )
-  })
+    );
+  });
 
-  it('throws when resolving an already rejected promise', () => {
-    const promise = new DeferredPromise<number>().catch(() => {})
-    expect(promise.state).toBe('pending')
-    promise.reject()
+  it("throws when resolving an already rejected promise", () => {
+    const promise = new DeferredPromise<number>().catch(() => {});
+    expect(promise.state).toBe("pending");
+    promise.reject();
 
     expect(() => promise.resolve(123)).toThrow(
       new TypeError(
         'Cannot resolve a DeferredPromise: illegal state ("rejected")'
       )
-    )
-  })
-})
+    );
+  });
+});
 
-describe('reject()', () => {
-  it('can be rejected without any reason', () => {
-    const promise = new DeferredPromise<void>().catch(() => {})
-    expect(promise.state).toBe('pending')
-    promise.reject()
+describe("reject()", () => {
+  it("can be rejected without any reason", () => {
+    const promise = new DeferredPromise<void>().catch(() => {});
+    expect(promise.state).toBe("pending");
+    promise.reject();
 
-    expect(promise.state).toBe('rejected')
-    expect(promise.result).toBeUndefined()
-    expect(promise.rejectionReason).toBeUndefined()
-  })
+    expect(promise.state).toBe("rejected");
+    expect(promise.result).toBeUndefined();
+    expect(promise.rejectionReason).toBeUndefined();
+  });
 
-  it('can be rejected with a reason', () => {
-    const promise = new DeferredPromise().catch(() => {})
-    expect(promise.state).toBe('pending')
+  it("can be rejected with a reason", () => {
+    const promise = new DeferredPromise().catch(() => {});
+    expect(promise.state).toBe("pending");
 
-    const rejectionReason = new Error('Something went wrong')
-    promise.reject(rejectionReason)
+    const rejectionReason = new Error("Something went wrong");
+    promise.reject(rejectionReason);
 
-    expect(promise.state).toBe('rejected')
-    expect(promise.result).toBeUndefined()
-    expect(promise.rejectionReason).toEqual(rejectionReason)
-  })
-})
+    expect(promise.state).toBe("rejected");
+    expect(promise.result).toBeUndefined();
+    expect(promise.rejectionReason).toEqual(rejectionReason);
+  });
+});
+
+describe("finally()", () => {
+  it('executes the "finally" block when the promise resolves', async () => {
+    const promise = new DeferredPromise<void>();
+    const finallyCallback = jest.fn();
+    promise.finally(finallyCallback);
+
+    // Promise is still pending.
+    expect(finallyCallback).not.toHaveBeenCalled();
+
+    promise.resolve();
+    await promise;
+
+    expect(finallyCallback).toHaveBeenCalledTimes(1);
+    expect(finallyCallback).toHaveBeenCalledWith();
+  });
+
+  it('executes the "finally" block when the promise rejects', async () => {
+    const promise = new DeferredPromise<void>().catch(() => {});
+
+    const finallyCallback = jest.fn();
+    promise.finally(finallyCallback);
+
+    // Promise is still pending.
+    expect(finallyCallback).not.toHaveBeenCalled();
+
+    promise.reject();
+    await promise;
+
+    expect(finallyCallback).toHaveBeenCalledTimes(1);
+    expect(finallyCallback).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
- Adds support for `.finally()` method on the deferred promise.
- Fixes an issue when catching an exception would still treat the deferred promise as unhandled (re-assign `this.promise` in the `then`/`catch`/`finally` methods).
- Adds JSDoc descriptions for the `.then()`, `.catch()`, and `.finally()` methods.