### PR TITLE
feat: throw IllegalStateError upon illegal state

### DIFF
--- a/src/DeferredPromise.ts
+++ b/src/DeferredPromise.ts
@@ -1,7 +1,11 @@
+import { IllegalStateError } from "./IllegalStateError";
+
 export type DeferredPromiseState = "pending" | "resolved" | "rejected";
+
 export type ResolveFunction<Data extends any, Result = void> = (
   data: Data
 ) => Result | PromiseLike<Result>;
+
 export type RejectFunction<Result = void> = (
   reason?: unknown
 ) => Result | PromiseLike<Result>;
@@ -31,8 +35,9 @@ export class DeferredPromise<Data extends any = void> {
     this.promise = new Promise<Data>((resolve, reject) => {
       this.resolve = (data) => {
         if (this.state !== "pending") {
-          throw new TypeError(
-            `Cannot resolve a DeferredPromise: illegal state ("${this.state}")`
+          throw new IllegalStateError(
+            "Cannot resolve a DeferredPromise: illegal state",
+            this.state
           );
         }
 
@@ -43,8 +48,9 @@ export class DeferredPromise<Data extends any = void> {
 
       this.reject = (reason) => {
         if (this.state !== "pending") {
-          throw new TypeError(
-            `Cannot reject a DeferredPromise: illegal state ("${this.state}")`
+          throw new IllegalStateError(
+            "Cannot reject a DeferredPromise: illegal state",
+            this.state
           );
         }
 

--- a/src/IllegalStateError.ts
+++ b/src/IllegalStateError.ts
@@ -1,0 +1,7 @@
+import { type DeferredPromiseState } from "./DeferredPromise";
+
+export class IllegalStateError extends Error {
+  constructor(message: string, public readonly state: DeferredPromiseState) {
+    super(message);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export * from './DeferredPromise'
+export * from "./DeferredPromise";
+export * from "./IllegalStateError";

--- a/test/DeferredPromise.test.ts
+++ b/test/DeferredPromise.test.ts
@@ -1,4 +1,5 @@
 import { DeferredPromise } from "../src";
+import { IllegalStateError } from "../src/IllegalStateError";
 
 describe("Promise-compliance", () => {
   it('can be listened to with ".then()"', (done) => {
@@ -105,8 +106,9 @@ describe("resolve()", () => {
     promise.resolve(123);
 
     expect(() => promise.resolve(456)).toThrow(
-      new TypeError(
-        'Cannot resolve a DeferredPromise: illegal state ("resolved")'
+      new IllegalStateError(
+        "Cannot resolve a DeferredPromise: illegal state",
+        "resolved"
       )
     );
   });
@@ -117,8 +119,9 @@ describe("resolve()", () => {
     promise.reject();
 
     expect(() => promise.resolve(123)).toThrow(
-      new TypeError(
-        'Cannot resolve a DeferredPromise: illegal state ("rejected")'
+      new IllegalStateError(
+        "Cannot resolve a DeferredPromise: illegal state",
+        "rejected"
       )
     );
   });


### PR DESCRIPTION
This will allow the consumer to react to illegal state errors. 